### PR TITLE
fixed TypeError

### DIFF
--- a/genius/api.py
+++ b/genius/api.py
@@ -202,7 +202,7 @@ class Genius(_API):
         # Create the Artist object
         artist = Artist(json_artist);
         
-        if max_songs > 0 or max_songs == None:
+        if max_songs is None or max_songs > 0:
             # Access the api_path found by searching
             artist_search_results = self._make_api_request((artist_id, 'artist-songs'))        
 


### PR DESCRIPTION
caused by 

```py
>>> artist = api.search_artist('Andy Shauf')
Searching for Andy Shauf...

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Me\Desktop\GeniusLyrics\genius\api.py", line 205, in sear
ch_artist
    if max_songs > 0 or max_songs == None:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```